### PR TITLE
Feature/ux minimize

### DIFF
--- a/configs/dev.ts
+++ b/configs/dev.ts
@@ -5,7 +5,7 @@ export const firebaseConfig = {
   storageBucket: "nounsmap-web-dev.appspot.com",
   messagingSenderId: "921564152867",
   appId: "1:921564152867:web:f52be744b25a8648059d96",
-  measurementId: "G-8HBS0HJ881"
+  measurementId: "G-8HBS0HJ881",
 };
 
 export const nounsMapConfig = {
@@ -37,21 +37,22 @@ export const privacyCircleConfig = {
 };
 
 export const ethereumConfig = {
-  validTokenContracts:[
+  validTokenContracts: [
     {
-      name:"NounsLove(testnets)",
-      chainId: "0x4", 
+      name: "NounsLove(testnets)",
+      chainId: "0x4",
       contractAddress: "0x1602155eB091F863e7e776a83e1c330c828ede19",
       openseaUrl: "https://testnets.opensea.io/assets/rinkeby",
       filter: null,
       idmask: 0,
     },
     {
-      name:"NamedNoun(polygon)",
-      chainId: "0x89", 
+      name: "NamedNoun(polygon)",
+      chainId: "0x89",
       contractAddress: "0x2953399124F0cBB46d2CbACD8A89cF0599974963",
       openseaUrl: "https://opensea.io/assets/matic",
-      filter: "0x4e4cd175f812f1ba784a69c1f8ac8daa52ad7e2b000000000000010000000001",
+      filter:
+        "0x4e4cd175f812f1ba784a69c1f8ac8daa52ad7e2b000000000000010000000001",
       idmask: 12,
     },
     {
@@ -61,7 +62,8 @@ export const ethereumConfig = {
       openseaUrl: "https://testnets.opensea.io/assets/rinkeby",
       filter: null,
       idmask: 0,
-    },  ]
+    },
+  ],
 };
 
 export const ContentsContract = {

--- a/configs/dev.ts
+++ b/configs/dev.ts
@@ -55,14 +55,6 @@ export const ethereumConfig = {
         "0x4e4cd175f812f1ba784a69c1f8ac8daa52ad7e2b000000000000010000000001",
       idmask: 12,
     },
-    {
-      name: "HappyToken(testnets)",
-      chainId: "0x4",
-      contractAddress: "0x4F700D279b7046BE3B31DcFD9D94166bF4E6FBb1",
-      openseaUrl: "https://testnets.opensea.io/assets/rinkeby",
-      filter: null,
-      idmask: 0,
-    },
   ],
 };
 
@@ -83,3 +75,24 @@ export const ContentsContract = {
   authorityTokenFilter: null,
   authorityTokenIdmask: 0,
 };
+
+export const featureConfig = {
+  enableNFTReq: false,
+};
+
+export const supportingEvents = [
+  {
+    eventId: 0,
+    name: {
+      ja: "日常の一コマ",
+      en: "DailyPhotos",
+    },
+  },
+  {
+    eventId: 1,
+    name: {
+      ja: "nouns全国バトンリレー",
+      en: "nousns All Japan baton relay",
+    },
+  },
+];

--- a/configs/prod.ts
+++ b/configs/prod.ts
@@ -5,7 +5,7 @@ export const firebaseConfig = {
   storageBucket: "nounsmap-web-prod.appspot.com",
   messagingSenderId: "297116670466",
   appId: "1:297116670466:web:c00780dd6d818858bae51b",
-  measurementId: "G-2TR3L7VH0H"
+  measurementId: "G-2TR3L7VH0H",
 };
 
 export const nounsMapConfig = {
@@ -37,24 +37,25 @@ export const privacyCircleConfig = {
 };
 
 export const ethereumConfig = {
-  validTokenContracts:[
+  validTokenContracts: [
     {
-      name:"NounsLove(testnets)",
-      chainId: "0x4", 
+      name: "NounsLove(testnets)",
+      chainId: "0x4",
       contractAddress: "0x1602155eB091F863e7e776a83e1c330c828ede19",
       openseaUrl: "https://testnets.opensea.io/assets/rinkeby",
       filter: null,
       idmask: 0,
     },
     {
-      name:"NamedNoun(polygon)",
-      chainId: "0x89", 
+      name: "NamedNoun(polygon)",
+      chainId: "0x89",
       contractAddress: "0x2953399124F0cBB46d2CbACD8A89cF0599974963",
       openseaUrl: "https://opensea.io/assets/matic",
-      filter: "0x4e4cd175f812f1ba784a69c1f8ac8daa52ad7e2b000000000000010000000001",
+      filter:
+        "0x4e4cd175f812f1ba784a69c1f8ac8daa52ad7e2b000000000000010000000001",
       idmask: 12,
     },
-  ]
+  ],
 };
 
 export const ContentsContract = {

--- a/configs/prod.ts
+++ b/configs/prod.ts
@@ -75,3 +75,24 @@ export const ContentsContract = {
   authorityTokenFilter: null,
   authorityTokenIdmask: 0,
 };
+
+export const featureConfig = {
+  enableNFTReq: false,
+};
+
+export const supportingEvents = [
+  {
+    eventId: 0,
+    name: {
+      ja: "日常の一コマ",
+      en: "DailyPhotos",
+    },
+  },
+  {
+    eventId: 1,
+    name: {
+      ja: "nouns全国バトンリレー",
+      en: "nousns All Japan baton relay",
+    },
+  },
+];

--- a/functions/src/functions/photo.ts
+++ b/functions/src/functions/photo.ts
@@ -137,6 +137,9 @@ export const posted = async (
       {
         uid,
         photoId,
+        title: pdata.title,
+        description: pdata.description,
+        eventId: pdata.eventId,
         iconURL: _iconURL,
         photoURL: _photoURL,
         lat: _lat,

--- a/functions/src/functions/photo.ts
+++ b/functions/src/functions/photo.ts
@@ -149,9 +149,6 @@ export const posted = async (
     );
     await db.doc(`users/${uid}/public_photos/${photoId}`).set(
       {
-        title: "NounsMap Photo & News share!",
-        description:
-          "We are planning to release easy photo and map share service",
         images: {
           ogp: {
             [600]: {

--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -17,7 +17,7 @@
           </div>
         </router-link>
       </li>
-      <li class="mr-3">
+      <li class="mr-3"  v-if="featureConfig.enableNFTReq">
         <router-link :to="localizedUrl('/nft')">
           <div
             class="flex justify-center items-center border border-white rounded hover:border-gray-200 text-blue-500 hover:bg-gray-200 py-2 px-4"
@@ -58,6 +58,7 @@ import router from "@/router";
 import { useStore } from "vuex";
 import { getLocalePath, useI18nParam } from "@/i18n/utils";
 import { auth } from "@/utils/firebase";
+import { featureConfig } from "@/config/project";
 
 import Languages from "@/components/Languages.vue";
 import NounsUser from "@/components/NounsUser.vue";
@@ -148,6 +149,7 @@ export default defineComponent({
     };
     useI18nParam();
     return {
+      featureConfig,
       guideLogin,
       guidePhoto,
       photoSelect,

--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -7,7 +7,7 @@
     <GuidePhoto ref="guidePhoto" :photoSelect="photoSelect" />
     <!-- Saved for future changes. Currently causes error. -->
     <!-- <template v-if="user.user"> {{ user.user.displayName }}!! </template> -->
-    <ul class="grid grid-cols-4 gap-0 justify-items-stretch">
+    <ul class="grid grid-cols-3 gap-0 justify-items-stretch">
       <li class="mr-3">
         <router-link :to="localizedUrl('/map')">
           <div
@@ -17,7 +17,7 @@
           </div>
         </router-link>
       </li>
-      <li class="mr-3"  v-if="featureConfig.enableNFTReq">
+      <li class="mr-3" v-if="featureConfig.enableNFTReq">
         <router-link :to="localizedUrl('/nft')">
           <div
             class="flex justify-center items-center border border-white rounded hover:border-gray-200 text-blue-500 hover:bg-gray-200 py-2 px-4"
@@ -109,16 +109,11 @@ export default defineComponent({
     });
     const routeCheck = () => {
       if (
-        route.path == getLocalePath(router, "/nft") ||
-        route.path == getLocalePath(router, "/nft_req")
-      ) {
-        photoSelect.value?.hide();
-      }
-      if (
         route.path == getLocalePath(router, "/map") ||
         route.path == getLocalePath(router, "/nft") ||
         route.path == getLocalePath(router, "/nft_req")
       ) {
+        photoSelect.value?.hide();
         //for not sign in user (isShown stored to memory, so if reloaded show again.)
         if (!user.value && !isShownGuideLogin) {
           guideLogin.value.open();

--- a/src/components/NounsMap.vue
+++ b/src/components/NounsMap.vue
@@ -1,6 +1,30 @@
 <template>
-  <div class="p-6" align="center">
+  <div class="flex flex-col p-6" align="center">
     <div align="center" v-if="photoLocal">
+      <div>
+      <div class="flex flex-row justify-center items-center m-4">
+        <span class="block text-gray-700 text-sm font-bold m-2"> {{ $t("label.name") }}: </span>
+        <input
+          type="text"
+          ref="nameRef"
+          maxlength="128"
+          minlength="1"
+          class="shadow appearance-none border rounded w-auto py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+        />
+      </div>
+      <div class="flex flex-row justify-center items-center m-4">
+        <span class="block text-gray-700 text-sm font-bold m-2">
+          {{ $t("label.description") }}:
+        </span>
+        <input
+          type="text"
+          ref="descRef"
+          maxlength="512"
+          minlength="1"
+          class="shadow appearance-none border rounded w-auto py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+        />
+      </div>    
+      </div>
       <div>
         {{ $t("message.selectPhotoLocation") }}<br />
         <label>{{ $t("message.spotPrivacyLevel") }} : </label>
@@ -173,8 +197,9 @@ export default defineComponent({
     const photoLocal = ref();
     const dataURL = ref<string>();
     const pictureURL = ref<string>();
-
     const processing = ref();
+    const nameRef = ref();
+    const descRef = ref();
 
     let locationCircle: google.maps.Circle | null;
 
@@ -223,12 +248,12 @@ export default defineComponent({
       mapObj.value = new mapInstance.value.maps.Map(mapRef.value, mapOptions);
       processing.value = false;
       pLevel.value = privacyCircleConfig.pLevel;
-        mapObj.value.setCenter(
-          new mapInstance.value.maps.LatLng(
-            defaultMapConfig.lan,
-            defaultMapConfig.lng
-          )
-        );
+      mapObj.value.setCenter(
+        new mapInstance.value.maps.LatLng(
+          defaultMapConfig.lan,
+          defaultMapConfig.lng
+        )
+      );
       routeCheck();
     });
 
@@ -343,6 +368,8 @@ export default defineComponent({
       pins["upload"]?.showPhoto();
       const pdata = generateNewPhotoData(
         _pid,
+        nameRef.value.value,
+        descRef.value.value,
         photoURL,
         photoLocal.value.file.name,
         storage_path,
@@ -521,6 +548,8 @@ export default defineComponent({
       pictureURL,
       photoLocal,
       processing,
+      nameRef,
+      descRef,      
       photoSelected,
       uploadPhoto,
       locationUpdated,
@@ -534,6 +563,6 @@ export default defineComponent({
 /* マップを画面幅に合わせる*/
 .nouns-map {
   width: 100vw;
-  height: 100vh;
+  height: 90vh;
 }
 </style>

--- a/src/components/PhotoView.vue
+++ b/src/components/PhotoView.vue
@@ -14,7 +14,7 @@
     >
       <img
         ref="imageRef"
-        class="rounded-md"
+        class="bg-cover rounded-md"
         :src="clickedPhoto.photoURL"
         alt="selected photo"
       />

--- a/src/components/PhotoView.vue
+++ b/src/components/PhotoView.vue
@@ -38,7 +38,7 @@
       </div>
     </div>
     <div
-      v-if="isWalletUser"
+      v-if="isWalletUser && featureConfig.enableNFTReq"
       class="row-start-5 col-start-4 col-span-1 row-span-1 shrink-0 py-2 flex justify-center items-center"
     >
       <div class="flex flex-column items-center" @click="nftRequest">
@@ -55,7 +55,7 @@
 <script lang="ts">
 import { useStore } from "vuex";
 import { User } from "firebase/auth";
-import { nounsMapConfig } from "@/config/project";
+import { nounsMapConfig,featureConfig } from "@/config/project";
 import {
   defineComponent,
   ref,
@@ -115,6 +115,7 @@ export default defineComponent({
     };
     return {
       nounsMapConfig,
+      featureConfig,
       clickedPhoto,
       isWalletUser,
       close,

--- a/src/components/PhotoView.vue
+++ b/src/components/PhotoView.vue
@@ -4,7 +4,7 @@
     v-if="clickedPhoto"
   >
     <div
-      class="col-start-4 row-span-1 col-span-1 flex justify-center items-center"
+      class="col-start-5 row-span-1 col-span-1 flex justify-center items-center"
       @click="close"
     >
       <i class="text-6xl material-icons text-white mr-2">cancel</i>
@@ -55,7 +55,7 @@
 <script lang="ts">
 import { useStore } from "vuex";
 import { User } from "firebase/auth";
-import { nounsMapConfig,featureConfig } from "@/config/project";
+import { nounsMapConfig, featureConfig } from "@/config/project";
 import {
   defineComponent,
   ref,

--- a/src/config/project.ts
+++ b/src/config/project.ts
@@ -79,3 +79,20 @@ export const ContentsContract = {
 export const featureConfig = {
   enableNFTReq: false,
 };
+
+export const supportingEvents = [
+  {
+    eventId: 0,
+    name: {
+      ja: "日常の一コマ",
+      en: "DailyPhotos",
+    },
+  },
+  {
+    eventId: 1,
+    name: {
+      ja: "nouns全国バトンリレー",
+      en: "nousns All Japan baton relay",
+    },
+  },
+];

--- a/src/config/project.ts
+++ b/src/config/project.ts
@@ -55,14 +55,6 @@ export const ethereumConfig = {
         "0x4e4cd175f812f1ba784a69c1f8ac8daa52ad7e2b000000000000010000000001",
       idmask: 12,
     },
-    {
-      name: "HappyToken(testnets)",
-      chainId: "0x4",
-      contractAddress: "0x4F700D279b7046BE3B31DcFD9D94166bF4E6FBb1",
-      openseaUrl: "https://testnets.opensea.io/assets/rinkeby",
-      filter: null,
-      idmask: 0,
-    },
   ],
 };
 
@@ -82,4 +74,8 @@ export const ContentsContract = {
   authorityTokenName: "NounsLove(TestNets)", //nouns love
   authorityTokenFilter: null,
   authorityTokenIdmask: 0,
+};
+
+export const featureConfig = {
+  enableNFTReq: false,
 };

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -22,6 +22,7 @@ const lang = {
   label: {
     name: "title",
     description: "description",
+    event: "event",
     creator: "creator",
     mint: "Mint",
     mintNotHasAuthority: "Mint(AuthorityToken needed)",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -22,6 +22,7 @@ const lang = {
   label: {
     name: "タイトル",
     description: "説明",
+    event: "イベント",
     creator: "作者",
     owner: "所有者",
     mint: "ミント",

--- a/src/models/photo.ts
+++ b/src/models/photo.ts
@@ -77,6 +77,8 @@ export interface NftPhoto {
 
 export const generateNewPhotoData = (
   pid: string,
+  title: string,
+  description: string,
   photoURL: string,
   org: string,
   path: string,
@@ -88,8 +90,8 @@ export const generateNewPhotoData = (
 ): PhotoOrgData => {
   const photoData = {
     id: pid,
-    title: "",
-    description: "",
+    title,
+    description,
     original_name: org,
     images: {
       resizedImages: {

--- a/src/models/photo.ts
+++ b/src/models/photo.ts
@@ -13,6 +13,7 @@ export interface PhotoPubData {
   photoURL: string;
   title: string | undefined;
   description: string | undefined;
+  eventId: number;
   lat: number;
   lng: number;
   zoom: number;
@@ -23,6 +24,7 @@ export interface PhotoOrgData {
   id: string;
   title: string | undefined;
   description: string | undefined;
+  eventId: number;
   original_name: string;
   images: {
     resizedImages: {
@@ -79,6 +81,7 @@ export const generateNewPhotoData = (
   pid: string,
   title: string,
   description: string,
+  eventId: number,
   photoURL: string,
   org: string,
   path: string,
@@ -92,6 +95,7 @@ export const generateNewPhotoData = (
     id: pid,
     title,
     description,
+    eventId,
     original_name: org,
     images: {
       resizedImages: {


### PR DESCRIPTION
* UXを投稿する機能にしぼる（nft 化する機能をconfigでhide）
* 写真がはみ出して表示されてしまうことがあることを修正
* Tweet時に自分が入力したタイトルが反映されるように修正
* 今後　関連イベントのみの地図写真が表示できるよう evnetIdをあわせて保存する
  - 現状入力できるイベント: "日常の一コマ"、" Nouns全国バトンリレー"
  - configで容易に追加可能

<img width="605" alt="image" src="https://user-images.githubusercontent.com/3196383/181398571-bafcff3b-a2bc-46d0-9dcf-784c10c887f7.png">


