### PR TITLE
Feature/nounsdaojp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 node_modules
 /dist
 
-
+functions/exportedlocal
 # local env files
 .env.local
 .env.*.local

--- a/configs/dev.ts
+++ b/configs/dev.ts
@@ -100,9 +100,10 @@ export const supportingEvents = [
   {
     eventId: 0,
     name: {
-      ja: "日常の一コマ",
-      en: "DailyPhotos",
+      ja: "自分履歴",
+      en: "self history",
     },
+    expired: 0,
   },
   {
     eventId: 1,
@@ -110,5 +111,14 @@ export const supportingEvents = [
       ja: "nouns全国バトンリレー",
       en: "nousns All Japan baton relay",
     },
+    expired: 90,
+  },
+  {
+    eventId: 2,
+    name: {
+      ja: "今日のNouns",
+      en: "Daily Nouns",
+    },
+    expired: 1,
   },
 ];

--- a/configs/dev.ts
+++ b/configs/dev.ts
@@ -39,6 +39,22 @@ export const privacyCircleConfig = {
 export const ethereumConfig = {
   validTokenContracts: [
     {
+      name: "NounsDaoJapan",
+      chainId: "0x1",
+      contractAddress: "0x898a7dbfddf13962df089fbc8f069fa7ce92cdbb",
+      openseaUrl: "https://opensea.io/assets/ethereum",
+      filter: null,
+      idmask: 0,
+    },
+    {
+      name: "NounsBatonRelay",
+      chainId: "0x1",
+      contractAddress: "0x34758B0D303608B05B0BF6A35714162ac8797DC2",
+      openseaUrl: "https://opensea.io/assets/ethereum",
+      filter: null,
+      idmask: 0,
+    },
+    {
       name: "NounsLove(testnets)",
       chainId: "0x4",
       contractAddress: "0x1602155eB091F863e7e776a83e1c330c828ede19",

--- a/configs/prod.ts
+++ b/configs/prod.ts
@@ -100,9 +100,10 @@ export const supportingEvents = [
   {
     eventId: 0,
     name: {
-      ja: "日常の一コマ",
-      en: "DailyPhotos",
+      ja: "自分履歴",
+      en: "self history",
     },
+    expired: 0,
   },
   {
     eventId: 1,
@@ -110,5 +111,14 @@ export const supportingEvents = [
       ja: "nouns全国バトンリレー",
       en: "nousns All Japan baton relay",
     },
+    expired: 90,
+  },
+  {
+    eventId: 2,
+    name: {
+      ja: "今日のNouns",
+      en: "Daily Nouns",
+    },
+    expired: 1,
   },
 ];

--- a/configs/prod.ts
+++ b/configs/prod.ts
@@ -39,6 +39,22 @@ export const privacyCircleConfig = {
 export const ethereumConfig = {
   validTokenContracts: [
     {
+      name: "NounsDaoJapan",
+      chainId: "0x1",
+      contractAddress: "0x898a7dbfddf13962df089fbc8f069fa7ce92cdbb",
+      openseaUrl: "https://opensea.io/assets/ethereum",
+      filter: null,
+      idmask: 0,
+    },
+    {
+      name: "NounsBatonRelay",
+      chainId: "0x1",
+      contractAddress: "0x34758B0D303608B05B0BF6A35714162ac8797DC2",
+      openseaUrl: "https://opensea.io/assets/ethereum",
+      filter: null,
+      idmask: 0,
+    },
+    {
       name: "NounsLove(testnets)",
       chainId: "0x4",
       contractAddress: "0x1602155eB091F863e7e776a83e1c330c828ede19",

--- a/functions/package.json
+++ b/functions/package.json
@@ -19,6 +19,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "@sentry/node": "^6.19.7",
+    "axios": "^0.27.2",
     "ethereumjs-util": "^7.1.4",
     "ethers": "^5.6.9",
     "express": "^4.18.1",

--- a/functions/src/functions/ethereum.ts
+++ b/functions/src/functions/ethereum.ts
@@ -7,7 +7,6 @@ const db = admin.firestore();
 // The user will see this message when MetaMask makes a "Signature Request"
 // to the user.
 const readableMessage =
-  "Welcome to nounsfes.com!\n\n" +
   'Please click "Sign" to sign in to unleash the power of your NFTs.\n\n' +
   "Nonce:\n";
 

--- a/functions/src/functions/image/imageUtil.ts
+++ b/functions/src/functions/image/imageUtil.ts
@@ -258,8 +258,8 @@ export const copyFileToBucket = async (fromObj, toPath) => {
 export const downloadFile = async (url) => {
   try {
     const tmpFile = path.join(os.tmpdir(), UUID()) + ".jpg";
-    const config = { responseType: "arraybuffer" };
-    const ret = await axios.get(url, config as AxiosRequestConfig);
+    const config: AxiosRequestConfig = { responseType: "arraybuffer" };
+    const ret = await axios.get(url, config);
     await fs.promises.writeFile(tmpFile, ret.data);
     return tmpFile;
   } catch (e) {

--- a/functions/src/functions/image/imageUtil.ts
+++ b/functions/src/functions/image/imageUtil.ts
@@ -4,6 +4,7 @@ import * as os from "os";
 import * as fs from "fs";
 import sharp from "sharp";
 import UUID from "uuid-v4";
+import axios, { AxiosRequestConfig } from "axios";
 
 import * as constant from "./constant";
 
@@ -252,4 +253,17 @@ export const copyFileToBucket = async (fromObj, toPath) => {
   const ret = await bucketObj.file(fromObj.name).copy(toPath);
   console.log("Image copied", ret);
   return;
+};
+
+export const downloadFile = async (url) => {
+  try {
+    const tmpFile = path.join(os.tmpdir(), UUID()) + ".jpg";
+    const config = { responseType: "arraybuffer" };
+    const ret = await axios.get(url, config as AxiosRequestConfig);
+    await fs.promises.writeFile(tmpFile, ret.data);
+    return tmpFile;
+  } catch (e) {
+    console.log("error", e);
+  }
+  return null;
 };

--- a/functions/src/functions/photo.ts
+++ b/functions/src/functions/photo.ts
@@ -20,13 +20,9 @@ const contractViewOnly = new ethers.Contract(
 const defaultIconURL =
   "https://firebasestorage.googleapis.com/v0/b/nounsmap-web-dev.appspot.com/o/images%2Fconfigs%2Ficons%2Fred160px.png?alt=media&token=a05a89db-013e-4361-a035-181829c31d56";
 
-const getIconPath = async (uid, pdata) => {
+const getIconPath = async (pdata) => {
   if (pdata.iconURL.length > 1) {
-    const iconObj = {
-      bucket: firebaseConfig.storageBucket,
-      name: `images/users/${uid}/public_icons/${pdata.iconId}/icon.svg`,
-    };
-    const tmpIcon = await imageUtil.downloadFileFromBucket(iconObj);
+    const tmpIcon = await imageUtil.downloadFile(pdata.iconURL);
     return await imageUtil.resizeLocal(tmpIcon, 96);
   } else {
     //const tempFilePath = path.join(os.tmpdir(), UUID());
@@ -67,7 +63,7 @@ const uploadImages = async (
       tmpFile = tmpPhoto;
       return imageUtil.resizeLocal(tmpPhoto, 220);
     }),
-    getIconPath(uid, pdata),
+    getIconPath(pdata),
   ]);
   const tmpBlend = await imageUtil.blendLocal(
     tmpFiles[0],
@@ -218,7 +214,7 @@ export const nftPosted = async (
         tmpFile = tmpPhoto;
         return imageUtil.resizeLocal(tmpPhoto, 600);
       }),
-      getIconPath(uid, pdata),
+      getIconPath(pdata),
     ]);
     // watermarked (same as original posted)
     const tmpBlend = await imageUtil.blendWaterMarkLocal(

--- a/functions/yarn.lock
+++ b/functions/yarn.lock
@@ -1406,6 +1406,14 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -2077,7 +2085,7 @@ colorspace@1.1.x:
     color "^3.1.3"
     text-hex "1.0.x"
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -3665,10 +3673,24 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
+follow-redirects@^1.14.9:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
+  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"

--- a/src/components/GuideLogin.vue
+++ b/src/components/GuideLogin.vue
@@ -38,6 +38,9 @@ export default defineComponent({
     const open = () => {
       isShow.value = true;
     };
+    const close = () => {
+      isShow.value = false;
+    };
     const gotoLogin = () => {
       isShow.value = false;
       router.push({
@@ -47,6 +50,7 @@ export default defineComponent({
     return {
       isShow,
       open,
+      close,
       gotoLogin,
     };
   },

--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -121,7 +121,7 @@ export default defineComponent({
         }
         if (user.value) {
           guideLogin.value.close();
-        }        
+        }
         if (
           user.value &&
           userPhotoState.value == "empty" &&

--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -119,6 +119,9 @@ export default defineComponent({
           guideLogin.value.open();
           isShownGuideLogin = true;
         }
+        if (user.value) {
+          guideLogin.value.close();
+        }        
         if (
           user.value &&
           userPhotoState.value == "empty" &&

--- a/src/components/NounsMap.vue
+++ b/src/components/NounsMap.vue
@@ -165,7 +165,7 @@ class Pin {
         shouldFocus: false,
       });
       if (data.pid) {
-        if(eventId > 0) {
+        if (eventId > 0) {
           router.push({
             name: getLocaleName(router, "eventphoto"),
             params: { eventId, photoId: data.pid },
@@ -339,14 +339,19 @@ export default defineComponent({
       const location = info.location ? info.location : mapObj.value.getCenter();
       mapObj.value.setCenter(location);
       mapObj.value.setZoom(12);
-      pins["upload"] = new Pin(mapInstance, mapObj, {
-        pid: null,
-        icon: defaultIcon(),
-        photoURL: "",
-        lat: location.lat,
-        lng: location.lng,
-        visibility: true,
-      }, 0);
+      pins["upload"] = new Pin(
+        mapInstance,
+        mapObj,
+        {
+          pid: null,
+          icon: defaultIcon(),
+          photoURL: "",
+          lat: location.lat,
+          lng: location.lng,
+          visibility: true,
+        },
+        0
+      );
       pins["upload"].hidePhoto();
     };
     const locationUpdated = () => {
@@ -548,17 +553,22 @@ export default defineComponent({
         //for default icon care
         const _iconurl = iconURL ? iconURL : require("@/assets/red160px.png");
         const _hsize = iconURL ? 80 : 30;
-        pins[doc.id] = new Pin(mapInstance, mapObj, {
-          pid: doc.id,
-          icon: {
-            url: _iconurl,
-            scaledSize: new mapInstance.value.maps.Size(80, _hsize),
+        pins[doc.id] = new Pin(
+          mapInstance,
+          mapObj,
+          {
+            pid: doc.id,
+            icon: {
+              url: _iconurl,
+              scaledSize: new mapInstance.value.maps.Size(80, _hsize),
+            },
+            photoURL: imageUrl,
+            lat,
+            lng,
+            visibility: true,
           },
-          photoURL: imageUrl,
-          lat,
-          lng,
-          visibility: true,
-        },0);
+          0
+        );
       });
       const latarray = photos.docs.map((doc) => {
         return doc.data().lat;
@@ -603,17 +613,22 @@ export default defineComponent({
             const size = iconURL.match(/red160px/)
               ? new mapInstance.value.maps.Size(80, 30)
               : new mapInstance.value.maps.Size(80, 80);
-            pins[doc.id] = new Pin(mapInstance, mapObj, {
-              pid: doc.id,
-              icon: {
-                url: iconURL,
-                scaledSize: size,
+            pins[doc.id] = new Pin(
+              mapInstance,
+              mapObj,
+              {
+                pid: doc.id,
+                icon: {
+                  url: iconURL,
+                  scaledSize: size,
+                },
+                photoURL,
+                lat,
+                lng,
+                visibility: true,
               },
-              photoURL,
-              lat,
-              lng,
-              visibility: true,
-            },0);
+              0
+            );
             if (lat != null && lng != null) {
               mapObj.value.setCenter(
                 new mapInstance.value.maps.LatLng(lat, lng)
@@ -663,17 +678,22 @@ export default defineComponent({
             pins[doc.id].delete();
             delete pins[doc.id];
           }
-          pins[doc.id] = new Pin(mapInstance, mapObj, {
-            pid: doc.id,
-            icon: {
-              url: _iconurl,
-              scaledSize: size,
+          pins[doc.id] = new Pin(
+            mapInstance,
+            mapObj,
+            {
+              pid: doc.id,
+              icon: {
+                url: _iconurl,
+                scaledSize: size,
+              },
+              photoURL,
+              lat,
+              lng,
+              visibility: true,
             },
-            photoURL,
-            lat,
-            lng,
-            visibility: true,
-          },_id);
+            _id
+          );
         }
         const latarray = photos.docs.map((doc) => {
           return doc.data().lat;

--- a/src/components/NounsMap.vue
+++ b/src/components/NounsMap.vue
@@ -341,7 +341,10 @@ export default defineComponent({
           shortID(nft.value.token.tokenID) +
           nft.value.name.trim() +
           shortID(nft.value.contractAddress);
-        const storage_path = `images/users/${_uid}/public_icons/${_id}/icon.svg`;
+        const post = nft.value.token.imageType
+          ? nft.value.token.imageType.slice(0, 3)
+          : "";
+        const storage_path = `images/users/${_uid}/public_icons/${_id}/icon.${post}`;
         const downloadURL = await getFileDownloadURL(storage_path);
         if (downloadURL) {
           //already icon exists
@@ -349,7 +352,16 @@ export default defineComponent({
           return [_id, downloadURL];
         } else {
           //new icon
-          const newURL = await uploadSVG(nft.value.token.image, storage_path);
+          const newURL = nft.value.token.buff
+            ? ((await uploadFile(
+                nft.value.token.buff,
+                storage_path,
+                nft.value.token.imageType
+              )) as string)
+            : ((await uploadSVG(
+                nft.value.token.image,
+                storage_path
+              )) as string);
           console.log("new icon", { newURL });
           return [_id, newURL];
         }
@@ -378,7 +390,8 @@ export default defineComponent({
       const storage_path = `images/users/${_uid}/public_photos/${_pid}/original.jpg`;
       const photoURL = (await uploadFile(
         photoLocal.value.resizedBlob,
-        storage_path
+        storage_path,
+        "jpeg"
       )) as string;
       pins["upload"]?.update({ photoURL });
       pins["upload"]?.showPhoto();

--- a/src/components/NounsMap.vue
+++ b/src/components/NounsMap.vue
@@ -232,8 +232,8 @@ export default defineComponent({
     const nameRef = ref();
     const descRef = ref();
     const i18n = useI18n();
-    const eventId = ref();
-    const viewEventId = ref();
+    const eventId = ref<number>(0);
+    const viewEventId = ref<number>(0);
     watch(viewEventId, () => {
       router.push({
         name: getLocaleName(router, "eventmap"),

--- a/src/components/NounsMap.vue
+++ b/src/components/NounsMap.vue
@@ -142,7 +142,8 @@ class Pin {
   constructor(
     mapInstance: Ref<typeof google>,
     mapObj: Ref<google.maps.Map>,
-    data: PinData
+    data: PinData,
+    eventId: number
   ) {
     this._mapInstance = mapInstance;
     this._mapObj = mapObj;
@@ -164,10 +165,17 @@ class Pin {
         shouldFocus: false,
       });
       if (data.pid) {
-        router.push({
-          name: getLocaleName(router, "photo"),
-          params: { photoId: data.pid },
-        });
+        if(eventId > 0) {
+          router.push({
+            name: getLocaleName(router, "eventphoto"),
+            params: { eventId, photoId: data.pid },
+          });
+        } else {
+          router.push({
+            name: getLocaleName(router, "photo"),
+            params: { photoId: data.pid },
+          });
+        }
       }
     });
     this._data = data;
@@ -338,7 +346,7 @@ export default defineComponent({
         lat: location.lat,
         lng: location.lng,
         visibility: true,
-      });
+      }, 0);
       pins["upload"].hidePhoto();
     };
     const locationUpdated = () => {
@@ -550,7 +558,7 @@ export default defineComponent({
           lat,
           lng,
           visibility: true,
-        });
+        },0);
       });
       const latarray = photos.docs.map((doc) => {
         return doc.data().lat;
@@ -605,7 +613,7 @@ export default defineComponent({
               lat,
               lng,
               visibility: true,
-            });
+            },0);
             if (lat != null && lng != null) {
               mapObj.value.setCenter(
                 new mapInstance.value.maps.LatLng(lat, lng)
@@ -665,7 +673,7 @@ export default defineComponent({
             lat,
             lng,
             visibility: true,
-          });
+          },_id);
         }
         const latarray = photos.docs.map((doc) => {
           return doc.data().lat;

--- a/src/components/NounsMap.vue
+++ b/src/components/NounsMap.vue
@@ -74,7 +74,7 @@
       </select>
     </div>
     <div>
-      <label class="m-2" for="sshowPicture">{{ $t("label.showPhoto") }}:</label>
+      <label class="m-2">{{ $t("label.showPhoto") }}:</label>
       <input type="checkbox" id="showPicture" v-model="isShowPicture" />
     </div>
   </div>

--- a/src/components/PhotoNFTRequest.vue
+++ b/src/components/PhotoNFTRequest.vue
@@ -211,7 +211,8 @@ export default defineComponent({
         const storage_path = `images/users/${user.value.uid}/public_photos/${photoId}/nft_original.jpg`;
         const photoURL = (await uploadFile(
           fileInput.value.files[0],
-          storage_path
+          storage_path,
+          "jpeg"
         )) as string;
         console.log({ photoURL });
         //photo meta data 更新

--- a/src/components/PhotoView.vue
+++ b/src/components/PhotoView.vue
@@ -100,9 +100,9 @@ export default defineComponent({
       store.commit("setClickedPhoto", undefined);
       if (route.params.eventId) {
         router.push({
-            name: getLocaleName(router, "eventmap"),
-            params: { eventId:route.params.eventId},
-          });
+          name: getLocaleName(router, "eventmap"),
+          params: { eventId: route.params.eventId },
+        });
       } else {
         router.push("../map");
       }

--- a/src/components/PhotoView.vue
+++ b/src/components/PhotoView.vue
@@ -10,11 +10,11 @@
       <i class="text-6xl material-icons text-white mr-2">cancel</i>
     </div>
     <div
-      class="row-start-2 col-start-2 col-span-3 row-span-3 col-end-5 justify-center items-center"
+      class="row-start-2 col-start-2 col-span-3 row-span-3 justify-center items-center"
     >
       <img
         ref="imageRef"
-        class="bg-cover rounded-md"
+        class="max-h-full rounded-md"
         :src="clickedPhoto.photoURL"
         alt="selected photo"
       />
@@ -93,7 +93,13 @@ export default defineComponent({
       checkUser();
     });
     const close = () => {
-      router.push("../map");
+      console.log(router);
+      store.commit("setClickedPhoto", undefined);
+      if (store.state.canGoBack) {
+        router.back();
+      } else {
+        router.push("../map");
+      }
     };
     const nftRequest = () => {
       store.commit("setNftRequestPhoto", clickedPhoto.value);

--- a/src/components/PhotoView.vue
+++ b/src/components/PhotoView.vue
@@ -54,6 +54,7 @@
 </template>
 <script lang="ts">
 import { useStore } from "vuex";
+import { useRoute } from "vue-router";
 import { User } from "firebase/auth";
 import { nounsMapConfig, featureConfig } from "@/config/project";
 import {
@@ -65,11 +66,13 @@ import {
 } from "vue";
 import router from "@/router";
 import { PhotoPubData } from "@/models/photo";
+import { getLocaleName } from "@/i18n/utils";
 
 export default defineComponent({
   emits: {},
   setup() {
     const store = useStore();
+    const route = useRoute();
     const user = computed<User>(() => store.state.user);
     watch(user, () => {
       checkUser();
@@ -95,8 +98,11 @@ export default defineComponent({
     const close = () => {
       console.log(router);
       store.commit("setClickedPhoto", undefined);
-      if (store.state.canGoBack) {
-        router.back();
+      if (route.params.eventId) {
+        router.push({
+            name: getLocaleName(router, "eventmap"),
+            params: { eventId:route.params.eventId},
+          });
       } else {
         router.push("../map");
       }

--- a/src/components/Wallet.vue
+++ b/src/components/Wallet.vue
@@ -277,10 +277,11 @@ export default defineComponent({
             ? nft.media[0].gateway
             : nft.metadata.image;
           const _type = nft.media[0].format
-            ? nft.media[0].format 
-            : nft.metadata.image.endsWith("svg") || nft.metadata.image.startsWith("data:image/svg")
-            ? "svg+xml" 
-            : undefined
+            ? nft.media[0].format
+            : nft.metadata.image.endsWith("svg") ||
+              nft.metadata.image.startsWith("data:image/svg")
+            ? "svg+xml"
+            : undefined;
           return {
             tokenID: nft.id.tokenId,
             displayID: shortID(nft.id.tokenId),
@@ -381,6 +382,7 @@ export default defineComponent({
             //const data = Buffer.from(ret.data , "base64").toString("ascii");
             const data = Buffer.from(ret.data).toString("base64");
             token.image = `data:image/${token.imageType};base64,` + data;
+            token.buff = Buffer.from(ret.data);
           }
           nft.value = {
             name: contract.value.name,

--- a/src/components/Wallet.vue
+++ b/src/components/Wallet.vue
@@ -25,6 +25,17 @@
                 <br />
               </p>
             </div>
+            <div v-if="isDebugTest">
+              <div class="flex flex-row justify-center items-center m-4">
+                <input
+                  type="text"
+                  ref="debugRef"
+                  maxlength="128"
+                  minlength="1"
+                  class="shadow appearance-none border rounded w-auto py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+                />
+              </div>
+            </div>
             <div v-if="tokens && tokens.length > 0">
               {{ $t("message.selectToken") }}:
               <select v-model="ownedTokenId">
@@ -144,6 +155,7 @@ import { nounsMapConfig, ethereumConfig } from "@/config/project";
 import { auth } from "@/utils/firebase";
 import { signInWithCustomToken } from "firebase/auth";
 import { generateNonce, verifyNonce, deleteNonce } from "../utils/functions";
+import { shortID } from "@/utils/utils";
 import { UserData } from "@/components/NounsUser.vue";
 import { requestAccount, switchNetwork, ChainIds } from "@/utils/MetaMask";
 import { Token, NFT, AlchemyOwnedTokens } from "@/models/SmartContract";
@@ -183,6 +195,8 @@ export default defineComponent({
     const tokens = ref<Array<Token>>([]);
     const isBusy = ref("");
     const isContentShown = ref(false);
+    const debugRef = ref();
+    const isDebugTest = ref(true);
     const open = () => (isContentShown.value = true);
     onMounted(async () => {
       if (store.getters.hasMetaMask) {
@@ -223,9 +237,10 @@ export default defineComponent({
             return "invalid";
         }
       })(contract.value.chainId);
+      const _account = isDebugTest.value ? debugRef.value.value : account.value;
       const request = {
         method: "get",
-        url: `${base}${nounsMapConfig.alchemy}/getNFTs/?owner=${account.value}`,
+        url: `${base}${nounsMapConfig.alchemy}/getNFTs/?owner=${_account}`,
       };
       try {
         const response = await axios(request);
@@ -258,15 +273,20 @@ export default defineComponent({
           }
         );
         tokens.value = target.map((nft: AlchemyOwnedTokens) => {
-          const displayID =
-            nft.id.tokenId.length > 18
-              ? nft.id.tokenId.slice(0, 6) + "..." + nft.id.tokenId.slice(-12)
-              : nft.id.tokenId;
+          const _image = nft.metadata.image.startsWith("ipfs")
+            ? nft.media[0].gateway
+            : nft.metadata.image;
+          const _type = nft.media[0].format
+            ? nft.media[0].format 
+            : nft.metadata.image.endsWith("svg") || nft.metadata.image.startsWith("data:image/svg")
+            ? "svg+xml" 
+            : undefined
           return {
             tokenID: nft.id.tokenId,
-            displayID: displayID,
+            displayID: shortID(nft.id.tokenId),
             tokenName: nft.title,
-            image: nft.metadata.image,
+            image: _image,
+            imageType: _type,
           };
         });
       } catch (error) {
@@ -278,12 +298,12 @@ export default defineComponent({
           (token) => token.tokenID == nftstore?.value?.token?.tokenID
         );
         ownedTokenId.value = selected[0]
-          ? selected[0].tokenID
+          ? parseInt(selected[0].tokenID)
           : tokens.value[0]
-          ? tokens.value[0].tokenID
+          ? parseInt(tokens.value[0].tokenID)
           : undefined;
       } else if (tokens.value[0]) {
-        ownedTokenId.value = tokens.value[0].tokenID;
+        ownedTokenId.value = parseInt(tokens.value[0].tokenID);
       }
     };
     const connect = async () => {
@@ -357,9 +377,10 @@ export default defineComponent({
               token.image,
               config as AxiosRequestConfig
             );
+            console.log(token.imageType);
             //const data = Buffer.from(ret.data , "base64").toString("ascii");
             const data = Buffer.from(ret.data).toString("base64");
-            token.image = "data:image/svg+xml;base64," + data;
+            token.image = `data:image/${token.imageType};base64,` + data;
           }
           nft.value = {
             name: contract.value.name,
@@ -409,6 +430,8 @@ export default defineComponent({
       isContentShown,
       isBusy,
       isSignedIn,
+      debugRef,
+      isDebugTest,
       open,
       connect,
       signIn,

--- a/src/components/Wallet.vue
+++ b/src/components/Wallet.vue
@@ -196,7 +196,7 @@ export default defineComponent({
     const isBusy = ref("");
     const isContentShown = ref(false);
     const debugRef = ref();
-    const isDebugTest = ref(true);
+    const isDebugTest = ref(false);
     const open = () => (isContentShown.value = true);
     onMounted(async () => {
       if (store.getters.hasMetaMask) {

--- a/src/components/Wallet.vue
+++ b/src/components/Wallet.vue
@@ -276,14 +276,16 @@ export default defineComponent({
           const _image = nft.metadata.image.startsWith("ipfs")
             ? nft.media[0].gateway
             : nft.metadata.image;
-          const _type = (()=>{
-            if(nft.media[0].format){
+          const _type = (() => {
+            if (nft.media[0].format) {
               return nft.media[0].format;
             } else {
-              if(nft.metadata.image.endsWith("svg") ||
-              nft.metadata.image.startsWith("data:image/svg")){
+              if (
+                nft.metadata.image.endsWith("svg") ||
+                nft.metadata.image.startsWith("data:image/svg")
+              ) {
                 return "svg+xml";
-              }else {
+              } else {
                 return undefined;
               }
             }
@@ -300,18 +302,18 @@ export default defineComponent({
         console.log(error);
       }
       console.log(tokens.value);
-      ownedTokenId.value = (()=>{
+      ownedTokenId.value = (() => {
         if (nftstore?.value?.token?.tokenID) {
           const selected = tokens.value.filter(
             (token) => token.tokenID == nftstore?.value?.token?.tokenID
           );
-          if(selected[0]){
+          if (selected[0]) {
             return parseInt(selected[0].tokenID);
-          } 
-        } 
-        if(tokens.value[0]){
-          return parseInt(tokens.value[0].tokenID)
-        }else{
+          }
+        }
+        if (tokens.value[0]) {
+          return parseInt(tokens.value[0].tokenID);
+        } else {
           return undefined;
         }
       })();

--- a/src/components/Wallet.vue
+++ b/src/components/Wallet.vue
@@ -276,12 +276,18 @@ export default defineComponent({
           const _image = nft.metadata.image.startsWith("ipfs")
             ? nft.media[0].gateway
             : nft.metadata.image;
-          const _type = nft.media[0].format
-            ? nft.media[0].format
-            : nft.metadata.image.endsWith("svg") ||
-              nft.metadata.image.startsWith("data:image/svg")
-            ? "svg+xml"
-            : undefined;
+          const _type = (()=>{
+            if(nft.media[0].format){
+              return nft.media[0].format;
+            } else {
+              if(nft.metadata.image.endsWith("svg") ||
+              nft.metadata.image.startsWith("data:image/svg")){
+                return "svg+xml";
+              }else {
+                return undefined;
+              }
+            }
+          })();
           return {
             tokenID: nft.id.tokenId,
             displayID: shortID(nft.id.tokenId),
@@ -294,18 +300,21 @@ export default defineComponent({
         console.log(error);
       }
       console.log(tokens.value);
-      if (nftstore?.value?.token?.tokenID) {
-        const selected = tokens.value.filter(
-          (token) => token.tokenID == nftstore?.value?.token?.tokenID
-        );
-        ownedTokenId.value = selected[0]
-          ? parseInt(selected[0].tokenID)
-          : tokens.value[0]
-          ? parseInt(tokens.value[0].tokenID)
-          : undefined;
-      } else if (tokens.value[0]) {
-        ownedTokenId.value = parseInt(tokens.value[0].tokenID);
-      }
+      ownedTokenId.value = (()=>{
+        if (nftstore?.value?.token?.tokenID) {
+          const selected = tokens.value.filter(
+            (token) => token.tokenID == nftstore?.value?.token?.tokenID
+          );
+          if(selected[0]){
+            return parseInt(selected[0].tokenID);
+          } 
+        } 
+        if(tokens.value[0]){
+          return parseInt(tokens.value[0].tokenID)
+        }else{
+          return undefined;
+        }
+      })();
     };
     const connect = async () => {
       isBusy.value = "Connecting Metamask...";
@@ -373,11 +382,8 @@ export default defineComponent({
         )[0];
         if (token) {
           if (token.image.indexOf("http") == 0) {
-            const config = { responseType: "arraybuffer" };
-            const ret = await axios.get(
-              token.image,
-              config as AxiosRequestConfig
-            );
+            const config: AxiosRequestConfig = { responseType: "arraybuffer" };
+            const ret = await axios.get(token.image, config);
             console.log(token.imageType);
             //const data = Buffer.from(ret.data , "base64").toString("ascii");
             const data = Buffer.from(ret.data).toString("base64");

--- a/src/config/project.ts
+++ b/src/config/project.ts
@@ -100,9 +100,10 @@ export const supportingEvents = [
   {
     eventId: 0,
     name: {
-      ja: "日常の一コマ",
-      en: "DailyPhotos",
+      ja: "自分履歴",
+      en: "self history",
     },
+    expired: 0,
   },
   {
     eventId: 1,
@@ -110,5 +111,14 @@ export const supportingEvents = [
       ja: "nouns全国バトンリレー",
       en: "nousns All Japan baton relay",
     },
+    expired: 90,
+  },
+  {
+    eventId: 2,
+    name: {
+      ja: "今日のNouns",
+      en: "Daily Nouns",
+    },
+    expired: 1,
   },
 ];

--- a/src/config/project.ts
+++ b/src/config/project.ts
@@ -39,6 +39,22 @@ export const privacyCircleConfig = {
 export const ethereumConfig = {
   validTokenContracts: [
     {
+      name: "NounsDaoJapan",
+      chainId: "0x1",
+      contractAddress: "0x898a7dbfddf13962df089fbc8f069fa7ce92cdbb",
+      openseaUrl: "https://opensea.io/assets/ethereum",
+      filter: null,
+      idmask: 0,
+    },
+    {
+      name: "NounsBatonRelay",
+      chainId: "0x1",
+      contractAddress: "0x34758B0D303608B05B0BF6A35714162ac8797DC2",
+      openseaUrl: "https://opensea.io/assets/ethereum",
+      filter: null,
+      idmask: 0,
+    },
+    {
       name: "NounsLove(testnets)",
       chainId: "0x4",
       contractAddress: "0x1602155eB091F863e7e776a83e1c330c828ede19",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -23,6 +23,8 @@ const lang = {
     name: "title",
     description: "description",
     event: "event",
+    viewEvent: "viewing",
+    showPhoto: "photos",
     creator: "creator",
     mint: "Mint",
     mintNotHasAuthority: "Mint(AuthorityToken needed)",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -40,7 +40,7 @@ const lang = {
     hello: "hello world",
     guidesignin: "You can share(Tweet) photo with maps, Try it now!",
     guidephoto:
-      "Click on the above button to upload your photos. Or try it with following button now!",
+      "Click on the above button to upload your photos. Or try it with following button now! Photos are public and shared, so please check the rights and privacy before posting.",
     pleasesignin:
       "Please SignIn. (If you want to convert your photos to NFT, please log in with MetaMask)",
     selectImage: "Select image",
@@ -49,7 +49,7 @@ const lang = {
     shareTwitter: "Share(Twitter)!!",
     processing: "Processing...",
     selectPhotoLocation:
-      "Please move the map so that the location of the photo is in the center.",
+      "Please move the map so that the location of the photo is in the center. Photos are public and shared, so please check the rights and privacy before posting.",
     selectContract: "Please select your NFT token contract",
     selectToken: "Please select your Token",
     youNeedMeta: "Please install MetaMask.",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -42,14 +42,14 @@ const lang = {
     guidesignin:
       "地図情報付きの写真を簡単にTwitterで共有できます！  今すぐ試してみませんか？",
     guidephoto:
-      "写真を投稿するには上記のボタンをクリック！　もしくは下記ボタンですぐに投稿できます！",
+      "写真を投稿するには上記のボタンをクリック！　もしくは下記ボタンですぐに投稿できます！(写真は公開、共有されますのでご注意ください)",
     pleasesignin:
       "ログイン方法を選んでください(写真をNFT化したい場合はMetaMaskでログインしてください)",
     selectImage: "画像を選んでください",
     uploadImage: "画像をアップロードしましょう!",
     shareTwitter: "Twitterにリンクを共有！",
     processing: "送信中です...",
-    selectPhotoLocation: "写真の場所が中心になるように地図を移動してください",
+    selectPhotoLocation: "写真の場所が中心になるように地図を移動してください。写真は公開、共有されますので、権利、プライバシーを確認の上投稿してください。",
     spotPrivacyLevel: "場所のプライバシーレベル",
     selectContract: "あなたのNFTの種類を選んでください",
     selectToken: "あなたのTokenを選んでください",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -23,6 +23,8 @@ const lang = {
     name: "タイトル",
     description: "説明",
     event: "イベント",
+    viewEvent: "表示イベント",
+    showPhoto: "写真表示",
     creator: "作者",
     owner: "所有者",
     mint: "ミント",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -49,7 +49,8 @@ const lang = {
     uploadImage: "画像をアップロードしましょう!",
     shareTwitter: "Twitterにリンクを共有！",
     processing: "送信中です...",
-    selectPhotoLocation: "写真の場所が中心になるように地図を移動してください。写真は公開、共有されますので、権利、プライバシーを確認の上投稿してください。",
+    selectPhotoLocation:
+      "写真の場所が中心になるように地図を移動してください。写真は公開、共有されますので、権利、プライバシーを確認の上投稿してください。",
     spotPrivacyLevel: "場所のプライバシーレベル",
     selectContract: "あなたのNFTの種類を選んでください",
     selectToken: "あなたのTokenを選んでください",

--- a/src/models/SmartContract.ts
+++ b/src/models/SmartContract.ts
@@ -4,6 +4,7 @@ export interface Token {
   tokenName: string;
   image: string;
   imageType: string;
+  buff: ArrayBuffer | undefined;
 }
 
 export interface TokenMeta {

--- a/src/models/SmartContract.ts
+++ b/src/models/SmartContract.ts
@@ -3,6 +3,7 @@ export interface Token {
   dispalyID: string;
   tokenName: string;
   image: string;
+  imageType: string;
 }
 
 export interface TokenMeta {
@@ -36,6 +37,14 @@ export interface AlchemyOwnedTokens {
   contract: {
     address: string;
   };
+  media: [
+    {
+      format: string;
+      gateway: string;
+      raw: string;
+      thumbnail: string;
+    }
+  ];
   metadata: {
     external_link: string;
     image: string;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -46,6 +46,11 @@ const routeChildren = (prefix: string): Array<RouteRecordRaw> => {
       component: NounsMap,
     },
     {
+      path: "map/:eventId/p/:photoId",
+      name: prefix + "eventphoto",
+      component: NounsMap,
+    },
+    {
       path: "about",
       component: About,
     },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -26,6 +26,11 @@ const routeChildren = (prefix: string): Array<RouteRecordRaw> => {
       component: NounsMap,
     },
     {
+      path: "map/:eventId",
+      name: prefix + "eventmap",
+      component: NounsMap,
+    },
+    {
       path: "nft_req",
       name: prefix + "nft_req",
       component: Mint,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -19,6 +19,7 @@ interface State {
   clickedPhoto: PhotoPubData | null;
   nftRequestPhoto: PhotoPubData | null;
   uploadPhoto: PhotoInfo | null;
+  canGoBack: boolean;
 }
 
 export default createStore<State>({
@@ -35,6 +36,7 @@ export default createStore<State>({
     clickedPhoto: null,
     nftRequestPhoto: null,
     uploadPhoto: null,
+    canGoBack: false,
   },
   mutations: {
     load(state: State) {
@@ -85,6 +87,9 @@ export default createStore<State>({
     },
     setUploadPhoto(state: State, photo: PhotoInfo | null) {
       state.uploadPhoto = photo;
+    },
+    setCanGoBack(state: State, goback: boolean) {
+      state.canGoBack = goback;
     },
   },
   getters: {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -6,11 +6,19 @@ import {
   getDownloadURL,
 } from "firebase/storage";
 
-export const uploadFile = (file: File, path: string) => {
+export const uploadFile = (
+  file: ArrayBuffer | File,
+  path: string,
+  meta: string | undefined
+) => {
   return new Promise((resolve, rejected) => {
     const storage = getStorage();
     const storageRef = ref(storage, path);
-    const uploadTask = uploadBytesResumable(storageRef, file);
+    const uploadTask = meta
+      ? uploadBytesResumable(storageRef, file, {
+          contentType: `image/${meta}`,
+        })
+      : uploadBytesResumable(storageRef, file);
 
     uploadTask.on(
       "state_changed",


### PR DESCRIPTION
nouns Dao jp  discord 上で受けた要望を加味して下記の機能追加
* 投稿されたevent の種類が一致した画像を地図上で一覧表示
   *  今回は supported eventについかした、Nouns全国バトンリレー、　今日のNouns　が対象
   *  default 投稿時は自分履歴として　一覧表示されないようにした
* ログイン時に選べるnft アイコンの種類に、　nounsdao jp pfp,  全国バトンリレー記念NFTを追加
   * それにともない nftのuriが ipfs のときの処理を追加（alchemyが配信するpngを保存する）
   * functions がわの処理もファイル名svg固定ではなく指定されたものをaxiosげDlするよう修正
*  投稿時に　「公開されるので権利とプライバシーを確認してから投稿するよう」注意文を追加

イベント表示例：
<img width="756" alt="image" src="https://user-images.githubusercontent.com/3196383/182003480-04eb8110-e079-4bc8-b016-43d20c190b62.png">
