### PR TITLE
add secure headers for hosting

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -18,6 +18,17 @@
       "**/.*",
       "**/node_modules/**"
     ],
+    "headers": [{
+      "source": "**",
+      "headers": [
+        { "key" : "Access-Control-Allow-Origin", "value" : "*" },
+        { "key" : "X-Frame-Options", "value" : "deny" },
+        { "key" : "X-Content-Type-Options", "value" : "nosniff" },
+        { "key" : "X-XSS-Protection", "value" : "1; mode=block" },
+        { "key" : "X-Permitted-Cross-Domain-Policies", "value" : "none" },
+        { "key" : "Referrer-Policy", "value": "no-referrer" }
+      ]
+    }],   
     "appAssociation": "AUTO",
     "rewrites": [
       {


### PR DESCRIPTION
firebase hosting の際に xss/csrf 対応のheader追加

dev 環境にて効果を確認
* 今まで
  *  <img width="582" alt="image" src="https://user-images.githubusercontent.com/3196383/189456775-8514cfc0-e654-4166-bed7-02938d07778c.png">

* 対応後
  * <img width="457" alt="image" src="https://user-images.githubusercontent.com/3196383/189456830-d61a7206-111e-4a16-ac25-36c0298e4255.png">
